### PR TITLE
Version 0.5.6

### DIFF
--- a/lib/distman/__init__.py
+++ b/lib/distman/__init__.py
@@ -35,7 +35,7 @@ distman distributes files and directories to versioned destinations.
 
 __author__ = "ryan@rsgalloway.com"
 __prog__ = "distman"
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 try:
     import envstack

--- a/lib/distman/dist.py
+++ b/lib/distman/dist.py
@@ -43,7 +43,7 @@ from distman.source import GitRepo
 @dataclass
 class Target:
     """Represents a distribution target with its name, source path, destination
-    path and dist options."""
+    path, type (folder, directory or link) and dist options."""
 
     name: str
     source: str
@@ -174,6 +174,9 @@ class Distributor(GitRepo):
 
         if not self.read_git_info():
             return False
+
+        if verbose:
+            self.log_distribution_info()
 
         targets_node = self.get_targets()
         if not targets_node:
@@ -403,7 +406,8 @@ class Distributor(GitRepo):
             if not os.path.lexists(dest):
                 log.info(f"Missing: {dest}")
             else:
-                log.info(f"{source} => {os.readlink(dest)}:")
+                target_type = util.get_path_type(source)[0]
+                log.info(f"{source} ={target_type}> {os.readlink(dest)}:")
         else:
             log.info(f"{source}:")
         for version_file, version_num, version_commit in version_list:

--- a/lib/distman/dist.py
+++ b/lib/distman/dist.py
@@ -43,7 +43,14 @@ from distman.source import GitRepo
 @dataclass
 class Target:
     """Represents a distribution target with its name, source path, destination
-    path, type (folder, directory or link) and dist options."""
+    path, type (folder, directory or link) and dist options.
+
+    name: The name of the target.
+    source: The source path of the target.
+    dest: The destination path of the target.
+    type: The type of the target (e.g., file, directory, link).
+    options: Optional dictionary of additional options for the target.
+    """
 
     name: str
     source: str

--- a/lib/distman/dist.py
+++ b/lib/distman/dist.py
@@ -93,7 +93,8 @@ def update_symlink(dest: str, target: str, dryrun: bool) -> bool:
         util.remove_object(dest)
     if dryrun:
         return True
-    return util.link_object(target, dest, target)
+    version_dest = util.get_version_dest(target)
+    return util.link_object(version_dest, dest, target)
 
 
 def get_version_dest(dest: str, version_num: int, short_head: Optional[str]) -> str:

--- a/lib/distman/source.py
+++ b/lib/distman/source.py
@@ -74,6 +74,11 @@ class Source(object):
         """Returns the targets defined in the dist file."""
         return self.root.get(config.TAG_TARGETS) if self.root else None
 
+    def log_distribution_info(self) -> None:
+        """Logs source information."""
+        log.info("Name: %s", self.name)
+        log.info("Path: %s", self.path)
+
     def read_dist_file(self, directory: str = ".") -> bool:
         """Reads the dist file from the specified directory.
 
@@ -108,7 +113,7 @@ class Source(object):
                 config.DIST_FILE_VERSION,
             )
         elif version > config.DIST_FILE_VERSION:
-            log.error(
+            log.warning(
                 "ERROR: This dist file is newer than supported version: %s (current %d)",
                 version,
                 config.DIST_FILE_VERSION,
@@ -116,7 +121,7 @@ class Source(object):
             self.root = None
             return False
 
-        log.info("Author: %s", self.author)
+        log.debug("Author: %s", self.author)
         return True
 
 
@@ -185,6 +190,13 @@ class GitRepo(Source):
             return self.repo.remotes[0].url
         return self.path
 
+    def log_distribution_info(self) -> None:
+        """Logs source repo information."""
+        log.info("Name: %s", self.name)
+        log.info("Path: %s", self.path)
+        log.info("Branch: %s", self.branch_name)
+        log.info("Head: %s (%s)", self.head, self.short_head)
+
     def read_git_info(self) -> bool:
         """Reads the git repository information and initializes the object."""
         self.branch_name = ""
@@ -208,7 +220,7 @@ class GitRepo(Source):
                 branch = self.repo.active_branch
                 self.branch_name = branch.name
                 if self.branch_name not in config.MAIN_BRANCHES:
-                    log.warning("Warning: Not on a main branch")
+                    log.warning("Warning: Not on a main branch: %s", self.branch_name)
             except (TypeError, AttributeError):
                 log.warning("Warning: Detached HEAD or no active branch")
 
@@ -217,12 +229,6 @@ class GitRepo(Source):
             self.repo = None
         except Exception as e:
             log.warning("Error reading git repo: %s", str(e))
-
-        log.info("Name: %s", self.name)
-        log.info("Path: %s", self.path)
-        if self.repo and self.branch_name:
-            log.info("Branch: %s", self.branch_name)
-            log.info("Head: %s (%s)", self.head, self.short_head)
 
         return True
 

--- a/lib/distman/source.py
+++ b/lib/distman/source.py
@@ -105,7 +105,7 @@ class Source(object):
 
         self.author = self.root.get(config.TAG_AUTHOR, util.get_user())
 
-        version = int(self.root.get(config.TAG_VERSION, 0))
+        version = int(self.root.get(config.TAG_VERSION, config.DIST_FILE_VERSION))
         if version < config.DIST_FILE_VERSION:
             log.warning(
                 "WARNING: Old dist file version: %s (current %d)",

--- a/lib/distman/util.py
+++ b/lib/distman/util.py
@@ -435,6 +435,20 @@ def sanitize_path(path: str) -> str:
     return path.replace("\\", "/").rstrip("/") if path else path
 
 
+def get_version_dest(target: str) -> str:
+    """Returns the version destination directory for a given target file.
+
+    The version destination is expected to be in the same directory as the
+    target file, named as config.DIR_VERSIONS, e.g.:
+
+        .../lib/python/distman -> versions/distman.1.0e98327
+
+    :param target: Path to target file.
+    :return: Path to the version destination.
+    """
+    return os.path.join(config.DIR_VERSIONS, os.path.basename(target))
+
+
 def get_link_full_path(link: str) -> str:
     """Returns the full path of a symbolic link.
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open(os.path.join(here, "README.md")) as f:
 
 setup(
     name="distman",
-    version="0.5.5",
+    version="0.5.6",
     description="Super simple file distribution",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_dist.py
+++ b/tests/test_dist.py
@@ -39,7 +39,7 @@ import shutil
 import pytest
 from unittest.mock import patch
 
-from distman import config, Distributor
+from distman import config, Distributor, util
 from distman.dist import (
     get_source_and_dest,
     confirm,
@@ -152,23 +152,6 @@ def test_confirm_yesNo():
         assert result is True
 
 
-def test_update_symlink_existing_link():
-    """ "Test the update_symlink function when the destination exists."""
-    dest = "path/to/existing/link"
-    target = "path/to/target"
-    dryrun = False
-
-    # mock the necessary functions
-    with patch("os.path.lexists", return_value=True), patch(
-        "distman.util.remove_object"
-    ) as mock_remove, patch("distman.util.link_object", return_value=True) as mock_link:
-        result = update_symlink(dest, target, dryrun)
-
-        mock_remove.assert_called_once_with(dest)
-        mock_link.assert_called_once_with(target, dest, target)
-        assert result is True
-
-
 def test_update_symlink_dryrun():
     """Test the update_symlink function when dryrun is True and the destination exists."""
     dest = "path/to/existing/link"
@@ -184,6 +167,23 @@ def test_update_symlink_dryrun():
         assert result is True
 
 
+def test_update_symlink_existing_link():
+    """ "Test the update_symlink function when the destination exists."""
+    dest = "path/to/existing/link"
+    target = "path/to/target"
+    dryrun = False
+
+    with patch("os.path.lexists", return_value=True), patch(
+        "distman.util.remove_object"
+    ) as mock_remove, patch("distman.util.link_object", return_value=True) as mock_link:
+        result = update_symlink(dest, target, dryrun)
+
+        mock_remove.assert_called_once_with(dest)
+        version_dest = util.get_version_dest(target)
+        mock_link.assert_called_once_with(version_dest, dest, target)
+        assert result is True
+
+
 def test_update_symlink_no_existing_link():
     """Test the update_symlink function when the destination does not exist."""
     dest = "path/to/nonexistent/link"
@@ -195,7 +195,8 @@ def test_update_symlink_no_existing_link():
     ) as mock_link:
         result = update_symlink(dest, target, dryrun)
 
-        mock_link.assert_called_once_with(target, dest, target)
+        version_dest = util.get_version_dest(target)
+        mock_link.assert_called_once_with(version_dest, dest, target)
         assert result is True
 
 

--- a/tests/test_dist.py
+++ b/tests/test_dist.py
@@ -168,7 +168,7 @@ def test_update_symlink_dryrun():
 
 
 def test_update_symlink_existing_link():
-    """ "Test the update_symlink function when the destination exists."""
+    """Test the update_symlink function when the destination exists."""
     dest = "path/to/existing/link"
     target = "path/to/target"
     dryrun = False


### PR DESCRIPTION
Version 0.5.6 RC

- fixes target version link
- if dist file version not found, assume current
- restores target type in log output
- only log distribution info if verbose
- bumps version to 0.5.6