### PR TITLE
Version 0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ clean:
 
 # Install target to install the builds using distman
 dryrun:
-	distman --dryrun
+	dist --dryrun
 
 # Install target to install the builds using distman
 install: build
-	distman --yes
+	dist --yes
 
 # Phony targets
 .PHONY: build dryrun install clean

--- a/README.md
+++ b/README.md
@@ -191,10 +191,11 @@ Most configuration is done in the `distman.env`
 Default config settings are in the config.py module. The following environment
 variables are supported:
 
-| Variable     | Description |
-|--------------|-------------|
-| $DEPLOY_ROOT | file deployment root directory |
-| $ENV         | target environment (e.g. prod or dev) |
-| $LOG_DIR     | directory to write log files |
-| $LOG_LEVEL   | logging level to use (DEBUG, INFO, etc) |
-| $ROOT        | dist root directory |
+| Variable        | Description |
+|-----------------|-------------|
+| $DEPLOY_ROOT    | file deployment root directory |
+| $ENV            | target environment (e.g. prod or dev) |
+| $IGNORE_MISSING | ignore missing source paths in targets |
+| $LOG_DIR        | directory to write log files |
+| $LOG_LEVEL      | logging level to use (DEBUG, INFO, etc) |
+| $ROOT           | dist root directory |

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ per-target:
 To dist files defined in a `dist.json` file (remove -d when ready):
 
 ```bash
-$ distman -d
+$ dist -d
 ```
 
 This will dist files to the `${DEPLOY_ROOT}` folder defined in the provided
@@ -162,7 +162,7 @@ To override the deployment folder, update the `distman.env` environment stack
 file then re-dist:
 
 ```bash
-$ distman [-d]
+$ dist [-d]
 ```
 
 By default, `distman` dists to a prod folder under `${DEPLOY_ROOT}`. This can be
@@ -170,7 +170,7 @@ changed at any time using `${ENV}` or updating or modifying the `distman.env`
 envstack file:
 
 ```bash
-$ ENV=dev distman [-d]
+$ ENV=dev dist [-d]
 ```
 
 This will change `prod` to `dev` in the target deplyment path. This is useful

--- a/bin/dist.bat
+++ b/bin/dist.bat
@@ -1,0 +1,2 @@
+@echo off
+python %~dp0\distman %*

--- a/bin/distman
+++ b/bin/distman
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 __doc__ = """
-Contains a simple executable for the distman cli.py module.
+Contains deprecated executable for the distman cli.py module.
 """
 
 import re
 import sys
-from distman.cli import main
+from distman.cli import main_legacy
 
 if __name__ == "__main__":
     sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
-    sys.exit(main())
+    sys.exit(main_legacy())

--- a/dist.json
+++ b/dist.json
@@ -3,7 +3,8 @@
     "targets": {
         "build": {
             "source": "build/*",
-            "destination": "{DEPLOY_ROOT}/lib/python/%1"
+            "destination": "{DEPLOY_ROOT}/lib/python/%1",
+            "options": {"match": "content"}
         },
         "bin": {
             "source": "bin/*",

--- a/lib/distman/__init__.py
+++ b/lib/distman/__init__.py
@@ -35,7 +35,7 @@ distman distributes files and directories to versioned destinations.
 
 __author__ = "ryan@rsgalloway.com"
 __prog__ = "distman"
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 try:
     import envstack

--- a/lib/distman/cli.py
+++ b/lib/distman/cli.py
@@ -137,6 +137,19 @@ def parse_args():
     return args
 
 
+def main_legacy():
+    """Main thread with deprecation warning."""
+    import warnings
+
+    warnings.warn(
+        "The 'distman' command is deprecated and will be removed in a future release. "
+        "Please use 'dist' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return main()
+
+
 def main():
     """Main thread."""
 

--- a/lib/distman/cli.py
+++ b/lib/distman/cli.py
@@ -105,6 +105,12 @@ def parse_args():
         help="dist all files, including ignorable files",
     )
     parser.add_argument(
+        "--ignore-missing",
+        action="store_true",
+        default=config.IGNORE_MISSING,
+        help="ignore missing files in dist file",
+    )
+    parser.add_argument(
         "-f",
         "--force",
         action="store_true",
@@ -237,6 +243,7 @@ def main():
             force=args.force,
             all=args.all,
             yes=args.yes,
+            ignore_missing=args.ignore_missing,
             dryrun=args.dryrun,
             versiononly=args.version_only,
             verbose=args.verbose,

--- a/lib/distman/config.py
+++ b/lib/distman/config.py
@@ -60,8 +60,9 @@ DIST_FILE_VERSION = 1
 DIST_INFO_EXT = ".dist"
 DIR_VERSIONS = "versions"
 
-# build directory settings
+# build and pipeline transform directory settings
 BUILD_DIR = os.getenv("BUILD_DIR", "build")
+TRANSFORM_DIR = os.getenv("TRANSFORM_DIR", ".distman")
 
 # logging settings
 LOG_NAME = "distman"

--- a/lib/distman/config.py
+++ b/lib/distman/config.py
@@ -99,6 +99,9 @@ IGNORABLE = [
     ".vscode",
 ]
 
+# ignore missing files in dist file
+IGNORE_MISSING = os.getenv("IGNORE_MISSING", "false").lower() in ("true", "1", "yes")
+
 # git repo settings
 LEN_HASH = 7
 LEN_MINHASH = 4

--- a/lib/distman/dist.py
+++ b/lib/distman/dist.py
@@ -248,7 +248,6 @@ class Distributor(GitRepo):
                     except Exception as e:
                         log.error(f"{e} resolving wildcard target {name}")
                         return False
-
             else:
                 try:
                     dest_resolved = util.sanitize_path(util.replace_vars(dest))
@@ -272,15 +271,15 @@ class Distributor(GitRepo):
                         log.error(f"Target {name}: Source '{source}' does not exist")
                         return False
 
-                if (
-                    not show
-                    and not force
-                    and (src_path in changed_files or src_path in changed_dirs)
-                ):
-                    log.info(
-                        f"Target {name}: Source '{source}' has uncommitted changes. Commit or use --force."
-                    )
-                    return False
+                # if (
+                #     not show
+                #     and not force
+                #     and (src_path in changed_files or src_path in changed_dirs)
+                # ):
+                #     log.info(
+                #         f"Target {name}: Source '{source}' has uncommitted changes. Commit or use --force."
+                #     )
+                #     return False
 
                 if (
                     not show
@@ -321,6 +320,13 @@ class Distributor(GitRepo):
         for t in target_list:
             util.create_dest_folder(t.dest, dryrun, yes)
 
+            # determine if the commit hash will be used for matching versions
+            match_options = t.options.get("match")
+            if not match_options or match_options == "commit_hash":
+                commit_hash = self.short_head
+            else:
+                commit_hash = None
+
             if not dryrun and not show:
                 util.write_dist_info(
                     t.dest,
@@ -345,7 +351,7 @@ class Distributor(GitRepo):
             matches = util.find_matching_versions(
                 source_path=source_path,
                 dest=t.dest,
-                commit_hash=self.short_head,
+                commit_hash=commit_hash,
                 version_list=version_list,
                 force=force,
             )

--- a/lib/distman/dist.py
+++ b/lib/distman/dist.py
@@ -322,7 +322,7 @@ class Distributor(GitRepo):
 
             # determine if the commit hash will be used for matching versions
             match_options = t.options.get("match")
-            if not match_options or match_options == "commit_hash":
+            if not match_options or match_options == "commit":
                 commit_hash = self.short_head
             else:
                 commit_hash = None
@@ -357,7 +357,7 @@ class Distributor(GitRepo):
             )
 
             if matches and not force:
-                match_file, match_num, _ = matches[-1]
+                match_file, _, _ = matches[-1]
                 if os.path.islink(t.dest) and os.readlink(t.dest).endswith(
                     os.path.basename(match_file)
                 ):

--- a/lib/distman/dist.py
+++ b/lib/distman/dist.py
@@ -271,15 +271,15 @@ class Distributor(GitRepo):
                         log.error(f"Target {name}: Source '{source}' does not exist")
                         return False
 
-                # if (
-                #     not show
-                #     and not force
-                #     and (src_path in changed_files or src_path in changed_dirs)
-                # ):
-                #     log.info(
-                #         f"Target {name}: Source '{source}' has uncommitted changes. Commit or use --force."
-                #     )
-                #     return False
+                if (
+                    not show
+                    and not force
+                    and (src_path in changed_files or src_path in changed_dirs)
+                ):
+                    log.info(
+                        f"Target {name}: Source '{source}' has uncommitted changes. Commit or use --force."
+                    )
+                    return False
 
                 if (
                     not show

--- a/lib/distman/dist.py
+++ b/lib/distman/dist.py
@@ -321,11 +321,16 @@ class Distributor(GitRepo):
             util.create_dest_folder(t.dest, dryrun, yes)
 
             # determine if the commit hash will be used for matching versions
-            match_options = t.options.get("match")
-            if not match_options or match_options == "commit":
+            match_option = t.options.get("match", "commit")
+
+            # FIXME: fallback shim until match option is fully implemented
+            if match_option not in ["commit", "content"]:
+                raise ValueError(f"Unsupported version match option '{match_option}'")
+
+            if match_option == "commit":
                 commit_hash = self.short_head
             else:
-                commit_hash = None
+                commit_hash = None  # don't use commit_hash in version matching
 
             if not dryrun and not show:
                 util.write_dist_info(

--- a/lib/distman/pipeline.py
+++ b/lib/distman/pipeline.py
@@ -40,6 +40,7 @@ import subprocess
 import importlib
 from typing import Callable, Optional, Dict, List, Tuple, Any
 
+from distman import config, util
 from distman.logger import log
 from distman.transform import TransformError
 
@@ -122,13 +123,16 @@ def run_pipeline(
 
     current = input_path
 
+    # the directory where transformed files will be stored
+    transform_dir = config.TRANSFORM_DIR
+
     for step_name, step in sort_pipeline(pipeline):
-        log.info("Step: '%s'", step_name)
+        log.info("Pipeline Step: '%s'", step_name)
 
         if os.path.isfile(current):
             output = os.path.join(
                 build_dir,
-                "distman",
+                transform_dir,
                 target.name,
                 step_name,
                 os.path.basename(input_path),
@@ -136,9 +140,9 @@ def run_pipeline(
             os.makedirs(os.path.dirname(output), exist_ok=True)
             shutil.copy2(current, output)
         elif os.path.isdir(current):
-            output = os.path.join(build_dir, "distman", target.name, step_name)
+            output = os.path.join(build_dir, transform_dir, target.name, step_name)
             os.makedirs(output, exist_ok=True)
-            shutil.copytree(current, output, dirs_exist_ok=True)
+            util.safe_copytree(current, output)
 
         if "script" in step:
             commands = step["script"]

--- a/lib/distman/source.py
+++ b/lib/distman/source.py
@@ -226,7 +226,7 @@ class GitRepo(Source):
 
         except git.InvalidGitRepositoryError:
             log.warning("WARNING: Not in a git repository")
-            self.repo = None
+            self.repo = False
         except Exception as e:
             log.warning("Error reading git repo: %s", str(e))
 

--- a/lib/distman/transform.py
+++ b/lib/distman/transform.py
@@ -72,7 +72,7 @@ def replace_tokens(input: str, output: str, tokens: dict) -> str:
     :return: The path to the output file or directory.
     """
     if os.path.isdir(input):
-        util.copy_directory(input, output)
+        shutil.copytree(input, output, dirs_exist_ok=True)
         _replace_tokens_in_dir(output, tokens)
     else:
         _replace_tokens_in_file(input, output, tokens)

--- a/lib/distman/transform.py
+++ b/lib/distman/transform.py
@@ -276,6 +276,19 @@ def _minify_html(input: str) -> str:
         return minified_html
 
 
+def _minify_text(input: str) -> str:
+    """Returns minified text source. Removes extra whitespace and newlines.
+
+    :param input: Path to the input text file.
+    :return: Minified text source as a string.
+    """
+
+    with open(input, "r") as infile:
+        text_content = infile.read()
+        minified_text = re.sub(r"\s+", " ", text_content.strip())
+        return minified_text
+
+
 def _minify_dir(directory: str, strict: bool = False) -> str:
     """Minify all files in a directory.
 
@@ -315,13 +328,19 @@ def _minify_file(input: str, output: str, strict: bool = False) -> str:
             minified = _minify_css(input)
         elif ext in (".html", ".htm"):
             minified = _minify_html(input)
+        elif ext in (".txt"):
+            minified = _minify_text(input)
         else:
             if strict:
                 raise TransformError(f"Unsupported file type for minification: {ext}")
             else:
                 log.warning("Unsupported file type for minification: %s", input)
-                shutil.copy2(input, output)
-                return output
+                if input != output:
+                    os.makedirs(os.path.dirname(output), exist_ok=True)
+                    shutil.copy2(input, output)
+                    return output
+                else:
+                    return input
 
     except Exception as e:
         raise TransformError(e)

--- a/lib/distman/transform.py
+++ b/lib/distman/transform.py
@@ -72,7 +72,7 @@ def replace_tokens(input: str, output: str, tokens: dict) -> str:
     :return: The path to the output file or directory.
     """
     if os.path.isdir(input):
-        shutil.copytree(input, output, dirs_exist_ok=True)
+        util.copy_directory(input, output)
         _replace_tokens_in_dir(output, tokens)
     else:
         _replace_tokens_in_file(input, output, tokens)

--- a/lib/distman/transform.py
+++ b/lib/distman/transform.py
@@ -72,7 +72,7 @@ def replace_tokens(input: str, output: str, tokens: dict) -> str:
     :return: The path to the output file or directory.
     """
     if os.path.isdir(input):
-        shutil.copytree(input, output, dirs_exist_ok=True)
+        util.safe_copytree(input, output)
         _replace_tokens_in_dir(output, tokens)
     else:
         _replace_tokens_in_file(input, output, tokens)
@@ -147,7 +147,7 @@ def byte_compile(input: str, output: str) -> str:
     :return: The path to the output file or directory after byte-compilation.
     """
     if os.path.isdir(input):
-        shutil.copytree(input, output, dirs_exist_ok=True)
+        util.safe_copytree(input, output)
         return _byte_compile_dir(output)
     elif os.path.isfile(input):
         os.makedirs(os.path.dirname(output), exist_ok=True)
@@ -211,7 +211,7 @@ def minify(input: str, output: str, strict: bool = False) -> str:
     """
 
     if os.path.isdir(input):
-        shutil.copytree(input, output, dirs_exist_ok=True)
+        util.safe_copytree(input, output)
         _minify_dir(output, strict=strict)
     else:
         os.makedirs(os.path.dirname(output), exist_ok=True)

--- a/lib/distman/util.py
+++ b/lib/distman/util.py
@@ -718,7 +718,10 @@ def safe_copytree(src: str, dst: str):
     :param dst: Destination directory path.
     """
 
-    for file in walk(src):
+    if os.path.abspath(src) == os.path.abspath(dst):
+        raise ValueError("Source and destination are the same: {src}")
+
+    for file in walk(src, exclude_paths=dst):
         relative_path = os.path.relpath(file, src)
         target_path = os.path.join(dst, relative_path)
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
@@ -754,7 +757,10 @@ def get_files(start: str, all_files: bool = False) -> List[str]:
 
 
 def walk(
-    path: str, exclude_ignorables: bool = True, followlinks: bool = False
+    path: str,
+    exclude_ignorables: bool = True,
+    followlinks: bool = False,
+    exclude_paths: Optional[List[str]] = None,
 ) -> Generator[str, None, None]:
     """Generator that yields relative file paths that are not ignorable.
     Will include nested directories and symbolic links to directories:
@@ -769,12 +775,15 @@ def walk(
     :param path: file system path.
     :param exclude_ignorables: exclude ignorable files.
     :param followlinks: follow symbolic links.
+    :param exclude_paths: list of paths to exclude from the search.
     :return: generator of file paths.
     """
     if not is_ignorable(path) and os.path.isfile(path):
         yield path
     for dirname, dirs, files in os.walk(path, topdown=True, followlinks=followlinks):
         if exclude_ignorables and is_ignorable(dirname):
+            continue
+        if exclude_paths and dirname in exclude_paths:
             continue
         for d in dirs:
             if exclude_ignorables and is_ignorable(d):

--- a/lib/distman/util.py
+++ b/lib/distman/util.py
@@ -721,11 +721,10 @@ def safe_copytree(src: str, dst: str):
     if os.path.abspath(src) == os.path.abspath(dst):
         raise ValueError(f"Source and destination are the same: {src}")
 
-    for file in walk(src, exclude_paths=dst):
+    for file in walk(src, exclude_paths=[dst]):
         relative_path = os.path.relpath(file, src)
         target_path = os.path.join(dst, relative_path)
         os.makedirs(os.path.dirname(target_path), exist_ok=True)
-        log.debug("Copying %s -> %s", file, target_path)
         shutil.copy2(file, target_path)
 
 

--- a/lib/distman/util.py
+++ b/lib/distman/util.py
@@ -710,6 +710,22 @@ def replace_vars(
     return "".join(result)
 
 
+def safe_copytree(src: str, dst: str):
+    """Safely copies a directory tree, avoiding infinite recursion, and skipping
+    ignorable file patterns defined in config.IGNORABLE.
+
+    :param src: Source directory path.
+    :param dst: Destination directory path.
+    """
+
+    for file in walk(src):
+        relative_path = os.path.relpath(file, src)
+        target_path = os.path.join(dst, relative_path)
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        log.debug("Copying %s -> %s", file, target_path)
+        shutil.copy2(file, target_path)
+
+
 def yesNo(question: str) -> bool:
     """Displays question text to user and reads yes/no input.
 

--- a/lib/distman/util.py
+++ b/lib/distman/util.py
@@ -105,7 +105,7 @@ def copy_file(source: str, dest: str) -> None:
     try:
         destdir = os.path.dirname(dest)
         if not os.path.isdir(destdir):
-            os.makedirs(destdir)
+            os.makedirs(destdir, exist_ok=True)
         if os.path.islink(source):
             linkto = os.readlink(source)
             try:

--- a/lib/distman/util.py
+++ b/lib/distman/util.py
@@ -719,7 +719,7 @@ def safe_copytree(src: str, dst: str):
     """
 
     if os.path.abspath(src) == os.path.abspath(dst):
-        raise ValueError("Source and destination are the same: {src}")
+        raise ValueError(f"Source and destination are the same: {src}")
 
     for file in walk(src, exclude_paths=dst):
         relative_path = os.path.relpath(file, src)
@@ -775,7 +775,7 @@ def walk(
     :param path: file system path.
     :param exclude_ignorables: exclude ignorable files.
     :param followlinks: follow symbolic links.
-    :param exclude_paths: list of paths to exclude from the search.
+    :param exclude_paths: list of paths to exclude from the search (optional).
     :return: generator of file paths.
     """
     if not is_ignorable(path) and os.path.isfile(path):
@@ -783,7 +783,7 @@ def walk(
     for dirname, dirs, files in os.walk(path, topdown=True, followlinks=followlinks):
         if exclude_ignorables and is_ignorable(dirname):
             continue
-        if exclude_paths and dirname in exclude_paths:
+        if exclude_paths and any(dirname.startswith(path) for path in exclude_paths):
             continue
         for d in dirs:
             if exclude_ignorables and is_ignorable(d):

--- a/lib/distman/util.py
+++ b/lib/distman/util.py
@@ -132,10 +132,6 @@ def copy_file(source: str, dest: str) -> None:
 def copy_directory(source: str, dest: str, all_files: bool = False) -> None:
     """Recursively copies a directory (ignores hidden files).
 
-    Substitutes tokens in the file if substitute_tokens is True. Tokens are in
-    the form of {TOKEN} and can be replaced with environment variables or default
-    values.
-
     :param source: Path to source directory.
     :param dest: Path to destination directory.
     :param all_files: Copy all files, including hidden and ignorable files.
@@ -152,10 +148,6 @@ def copy_directory(source: str, dest: str, all_files: bool = False) -> None:
 def copy_object(source: str, dest: str, all_files: bool = False) -> None:
     """Copies, or links, a file or directory recursively (ignores hidden
     files).
-
-    Substitutes tokens in the file if substitute_tokens is True. Tokens are in
-    the form of {TOKEN} and can be replaced with environment variables or default
-    values.
 
     :param source: Path to source file, link or directory.
     :param dest: Path to destination file or directory.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open(os.path.join(here, "README.md")) as f:
 
 setup(
     name="distman",
-    version="0.6.1",
+    version="0.7.0",
     description="Simple software distribution for complex pipelines",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ setup(
     packages=find_packages("lib"),
     entry_points={
         "console_scripts": [
-            "distman = distman.cli:main",
+            "dist = distman.cli:main",
+            "distman = distman.cli:main_legacy",
         ],
     },
     install_requires=[

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -329,7 +329,7 @@ def test_find_matching_versions(temp_dir):
 
 
 def test_safe_copytree(temp_dir):
-    """Test the safe_copytree function to ensure it correctly copies directory trees."""
+    """Test the safe_copytree function to ensure it correctly copies trees."""
     src_dir = os.path.join(temp_dir, "src")
     dst_dir = os.path.join(temp_dir, "dst")
     os.makedirs(src_dir, exist_ok=True)
@@ -360,6 +360,25 @@ def test_safe_copytree(temp_dir):
         assert f.read() == "This is file 1."
     with open(os.path.join(dst_dir, "subdir", "file2.txt"), "r") as f:
         assert f.read() == "This is file 2."
+
+
+def test_safe_copytree_into_subdir(temp_dir):
+    """Test the safe_copytree function to ensure it does not copy recursively."""
+    src_dir = os.path.join(temp_dir, "src")
+    dst_dir = os.path.join(src_dir, "subdir")  # dst is a subdir of src
+
+    os.makedirs(src_dir, exist_ok=True)
+    with open(os.path.join(src_dir, "file1.txt"), "w") as f:
+        f.write("This is file 1.")
+
+    # perform the copy
+    util.safe_copytree(src_dir, dst_dir)
+
+    assert os.path.exists(os.path.join(dst_dir, "file1.txt"))
+
+    # check the contents of the copied files
+    with open(os.path.join(dst_dir, "file1.txt"), "r") as f:
+        assert f.read() == "This is file 1."
 
 
 def test_safe_copytree_valueerror(temp_dir):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -326,3 +326,46 @@ def test_find_matching_versions(temp_dir):
     # test with force option, should match commitA
     results = util.find_matching_versions(source_file, target_file, force=True)
     assert len(results) == 2
+
+
+def test_safe_copytree(temp_dir):
+    """Test the safe_copytree function to ensure it correctly copies directory trees."""
+    src_dir = os.path.join(temp_dir, "src")
+    dst_dir = os.path.join(temp_dir, "dst")
+    os.makedirs(src_dir, exist_ok=True)
+
+    # create some test files and directories
+    with open(os.path.join(src_dir, "file1.txt"), "w") as f:
+        f.write("This is file 1.")
+    os.makedirs(os.path.join(src_dir, "subdir"), exist_ok=True)
+    with open(os.path.join(src_dir, "subdir", "file2.txt"), "w") as f:
+        f.write("This is file 2.")
+
+    assert os.path.exists(os.path.join(src_dir, "file1.txt"))
+    assert os.path.exists(os.path.join(src_dir, "subdir", "file2.txt"))
+
+    # double-check the source directory structure
+    files = [f for f in util.walk(src_dir)]
+    assert len(files) == 2
+
+    # perform the copy
+    util.safe_copytree(src_dir, dst_dir)
+
+    # check if the files were copied correctly
+    assert os.path.exists(os.path.join(dst_dir, "file1.txt"))
+    assert os.path.exists(os.path.join(dst_dir, "subdir", "file2.txt"))
+
+    # check the contents of the copied files
+    with open(os.path.join(dst_dir, "file1.txt"), "r") as f:
+        assert f.read() == "This is file 1."
+    with open(os.path.join(dst_dir, "subdir", "file2.txt"), "r") as f:
+        assert f.read() == "This is file 2."
+
+
+def test_safe_copytree_valueerror(temp_dir):
+    """Test the safe_copytree function to ensure it raises ValueError when
+    trying to copy to the same directory."""
+    src_dir = os.path.join(temp_dir, "src")
+
+    with pytest.raises(ValueError):
+        util.safe_copytree(src_dir, src_dir)


### PR DESCRIPTION
Version 0.7.0 RC

- Introduces a new dist command while deprecating the legacy distman command with a warning
- Adds support for ignoring missing source files and content-based version matching
- Adds an `--ignore-missing` cli option to ignore missing target sources
- Implements a new safe_copytree utility function to prevent infinite recursion during directory copying
- Addresses issue #50 
- Addresses issue #54 
- Addresses issue #59 
- Addresses issue #60 
- Bumps version to 0.7.0